### PR TITLE
Fix double-lores conversion

### DIFF
--- a/src/b2d.c
+++ b/src/b2d.c
@@ -287,6 +287,7 @@ documentation can be reviewed for additional information.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 #include "b2d.h"
 
@@ -2063,14 +2064,14 @@ int savelofragment() {
         break;
       /* first 40 bytes goes to auxiliary memory (even pixels) */
       for (x = 0; x < 40; x++) {
-        remap = dhrgetpixel(x, y);
+        remap = dhrgetpixel(x*2, y);
         temp = dloauxcolor[remap];
         setlopixel(temp, x, y, 1);
       }
       /* followed by the interleaf (odd pixels)
          next 40 bytes goes to main memory */
       for (x = 0; x < 40; x++) {
-        temp = dhrgetpixel(x, y);
+        temp = dhrgetpixel(lores ? x : x*2+1, y);
         setlopixel(temp, x + 40, y, 1);
       }
     }
@@ -2130,7 +2131,7 @@ int savelofragment() {
       memset(hgrbuf, 0, LOBINSIZE);
       for (y = 0; y < 48; y++) {
         for (x = 0; x < 40; x++) {
-          remap = dhrgetpixel(x, y);
+          remap = dhrgetpixel(x*2, y);
           temp = dloauxcolor[remap];
           setlopixel(temp, x, y, 0);
         }
@@ -2158,7 +2159,7 @@ int savelofragment() {
     memset(hgrbuf, 0, LOBINSIZE);
     for (y = 0; y < 48; y++) {
       for (x = 0; x < 40; x++) {
-        temp = dhrgetpixel(x, y);
+        temp = dhrgetpixel(lores ? x : x*2+1, y);
         setlopixel(temp, x, y, 0);
       }
     }


### PR DESCRIPTION
DLR conversion produces an 80x48 source bitmap, then needs to output even columns of pixels for the aux memory half and odd columns of pixels for the main memory half. The conversion was incorrectly processing just the first 40 pixels of each row twice.

Tweak the coordinate lookups during the output pass to get the correct pixels.